### PR TITLE
Update server.js

### DIFF
--- a/2015/server.js
+++ b/2015/server.js
@@ -367,7 +367,7 @@ if (plugins.includes('react')) {
   rules['react/jsx-no-undef'] = 2;
   rules['react/jsx-pascal-case'] = [ 2, { allowAllCaps: false }];
   rules['react/jsx-sort-props'] = 0;
-  rules['react/jsx-space-before-closing'] = [ 2, 'always' ];
+  rules['react/jsx-tag-spacing'] = 2;
   rules['react/jsx-uses-react'] = 2;
   rules['react/jsx-uses-vars'] = 2;
   rules['react/jsx-wrap-multilines'] = 2;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     {
       "name": "Matthias Wagler",
       "email": "matthias.wagler@thenativeweb.io"
+    },
+    {
+      "name": "Stefan Heine",
+      "email": "stefan.heine@microfocus.com"
     }
   ],
   "main": "2015/server.js",


### PR DESCRIPTION
To avoid the warning:
The react/jsx-space-before-closing rule is deprecated. Please use the react/jsx-tag-spacing rule with the "beforeSelfClosing" option instead.