### PR TITLE
Allow any in rule @typescript-eslint/promise-function-async.

### DIFF
--- a/node.js
+++ b/node.js
@@ -800,7 +800,7 @@ const overrides = [
       '@typescript-eslint/prefer-regexp-exec': 'error',
       '@typescript-eslint/prefer-string-starts-ends-with': 'error',
       '@typescript-eslint/promise-function-async': [ 'error', {
-        allowAny: false,
+        allowAny: true,
         allowedPromiseNames: [],
         checkArrowFunctions: true,
         checkFunctionDeclarations: true,


### PR DESCRIPTION
This rule previously prevented code like this:

```typescript
const foo = function (val: any): any {
  return val;
}
```

Because `val`'s type `any` also includes `Promise`s.

In my opinion explicit use of `any` doesn't need additional checks like this.