### PR TITLE
Allow T as type name.

### DIFF
--- a/node.js
+++ b/node.js
@@ -689,7 +689,7 @@ const overrides = [
       }],
       'func-call-spacing': 'off',
       '@typescript-eslint/func-call-spacing': [ 'error', 'never' ],
-      '@typescript-eslint/generic-type-naming': [ 'error', '^T[A-Z][a-zA-Z]+$' ],
+      '@typescript-eslint/generic-type-naming': [ 'error', '^(T|T[A-Z][a-zA-Z]+)$' ],
       indent: 'off',
       '@typescript-eslint/indent': [ 'error', 2, {
         SwitchCase: 1,


### PR DESCRIPTION
Hey @yeldiRium 😊 

Although it makes sense to enforce generic type names to be of form `TKey` or `TValue`, but in simple cases also a single `T` might be fine. This change allows this.

If you are fine with this, could you please squash / merge this PR and publish a new version?