### PR TITLE
Allow class fields starting with underscores.

### DIFF
--- a/node.js
+++ b/node.js
@@ -335,7 +335,7 @@ let rules = {
   }],
   'no-underscore-dangle': [ 'error', {
     allow: [],
-    allowAfterThis: false,
+    allowAfterThis: true,
     allowAfterSuper: false,
     enforceInMethodNames: true
   }],


### PR DESCRIPTION
This resolves a conflict with @typescript-eslint/member-naming.