### PR TITLE
Enable no-unused-vars rule again instead of disabling it twice

### DIFF
--- a/lib/isInstalled.js
+++ b/lib/isInstalled.js
@@ -17,7 +17,7 @@ const isInstalled = function (...names) {
       // bindings. Hence we disable this rule here instead of removing the
       // non-needed variable.
     } catch (ex) {
-      /* eslint-disable no-unused-vars */
+      /* eslint-enable no-unused-vars */
       return false;
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     {
       "name": "Hannes Leutloff",
       "email": "hannes.leutloff@thenativeweb.io"
+    },
+    {
+      "name": "Henning Storck",
+      "email": "henning@slightlyblack.com"
     }
   ],
   "main": "node.js",


### PR DESCRIPTION
In the `lib/isInstalled.js` the rule `no-unused-vars` was disabled, but wasn't enabled again. Seems like to be a copy and paste fault.