### PR TITLE
fix: Fixed no-shadow rule for typescript causing errors with enums

### DIFF
--- a/node.js
+++ b/node.js
@@ -915,6 +915,8 @@ const overrides = [
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/no-parameter-properties': 'off',
       '@typescript-eslint/no-require-imports': 'error',
+      'no-shadow': 'off',
+      '@typescript-eslint/no-shadow': [ 'error', { builtinGlobals: false, hoist: 'functions', allow: []}],
       '@typescript-eslint/no-this-alias': [ 'error', {
         allowDestructuring: false,
         allowedNames: []


### PR DESCRIPTION
The ES-Lint `no-shadow` rule does not play well in TypeScript Projects.
That's why it is recommended to use the overwritten `TypeScript`-Version in TypeScript-Projects.

E.g. if this is not done, defining Enums will result in errors like described [in this stackoverflow question](https://stackoverflow.com/questions/63961803/eslint-says-all-enums-in-typescript-app-are-already-declared-in-the-upper-scope).

