### PR TITLE
fix: Disable ESLint's built-in rule default-param-last in TypeScript …

### DIFF
--- a/node.js
+++ b/node.js
@@ -816,6 +816,7 @@ const overrides = [
         prefer: 'no-type-imports',
         disallowTypeAnnotations: true
       }],
+      'default-param-last': 'off',
       '@typescript-eslint/default-param-last': 'error',
       'dot-notation': 'off',
       '@typescript-eslint/dot-notation': [ 'error', {


### PR DESCRIPTION
…context.