### PR TITLE
Add react hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ const compiledESLintRules = betterRules.compile(betterRulesRecord);
 2. Rules are now in **camelCase**.
 3. **error** is the default and only for all rules.
 
-### UsePlugin-Hook
+### withPlugin-Hook
 
-You can use the `usePlugin` hook to avoid having to put plugin-rules in quotes (`'react/test-rule'`) like this:
+You can use the `withPlugin` hook to avoid having to put plugin-rules in quotes (`'react/test-rule'`) like this:
 
 ```typescript
 import { betterRules } from 'eslint-config-es'
 
-const reactRules: BetterRulesRecord = betterRules.usePlugin('react', {
+const reactRules: BetterRulesRecord = betterRules.withPlugin('react', {
   booleanPropNaming: false
 });
 ```
@@ -118,7 +118,7 @@ const weirdMix: BetterRulesRecord = {
 };
 
 const betterDefiniton: BetterRulesRecord = 
-  betterRules.usePlugin('@typescript-eslint', {
+  betterRules.withPlugin('@typescript-eslint', {
     arrayType: []
   };
 ```

--- a/lib/betterRules/index.ts
+++ b/lib/betterRules/index.ts
@@ -1,10 +1,10 @@
 import { BetterRulesRecord } from './BetterRulesRecord';
 import { compile } from './compile';
-import { usePlugin } from './usePlugin';
+import { withPlugin } from './withPlugin';
 
 export {
   compile,
-  usePlugin
+  withPlugin
 };
 
 export type {

--- a/lib/betterRules/withPlugin.ts
+++ b/lib/betterRules/withPlugin.ts
@@ -1,11 +1,11 @@
 import { BetterRulesRecord } from './BetterRulesRecord';
 import { curry, mapKeys } from 'lodash';
 
-const usePlugin = curry(
+const withPlugin = curry(
   (pluginName: string, rules: BetterRulesRecord): BetterRulesRecord =>
     mapKeys(rules, (value, key): string => `${pluginName}/${key}`)
 );
 
 export {
-  usePlugin
+  withPlugin
 };

--- a/lib/defaultConfiguration.ts
+++ b/lib/defaultConfiguration.ts
@@ -10,6 +10,7 @@ import {
   importRules,
   mochaRules,
   react,
+  reactHooks,
   sharedCoreTypescript,
   sharedImportTypescript,
   typescript,
@@ -45,6 +46,7 @@ const settings = {};
 
 if (isInstalled('react')) {
   plugins.push('react');
+  plugins.push('react-hooks');
 
   // @ts-expect-error react is actually set by the plugin.
   settings.react = { version: 'detect' };
@@ -77,7 +79,8 @@ const fixReactEs6Rule = (reactRulesRecord: Linter.RulesRecord): Linter.RulesReco
 if (plugins.includes('react')) {
   rules = {
     ...rules,
-    ...fixReactEs6Rule(compile(react))
+    ...fixReactEs6Rule(compile(react)),
+    ...compile(reactHooks)
   };
 }
 

--- a/lib/rules/comments.ts
+++ b/lib/rules/comments.ts
@@ -1,6 +1,6 @@
-import { usePlugin } from '../betterRules';
+import { withPlugin } from '../betterRules';
 
-const comments = usePlugin('eslint-comments', {
+const comments = withPlugin('eslint-comments', {
   disableEnablePair: [],
   noAggregatingEnable: [],
   noDuplicateDisable: [],

--- a/lib/rules/extended.ts
+++ b/lib/rules/extended.ts
@@ -1,6 +1,6 @@
-import { usePlugin } from '../betterRules';
+import { withPlugin } from '../betterRules';
 
-const extended = usePlugin('extended', {
+const extended = withPlugin('extended', {
   // eslint-disable-next-line extended/consistent-err-names
   consistentErrNames: [ 'prefix' ]
 });

--- a/lib/rules/import.ts
+++ b/lib/rules/import.ts
@@ -1,7 +1,7 @@
-import { usePlugin } from '../betterRules';
+import { withPlugin } from '../betterRules';
 
 // Can not name it 'import' as this is a reserved keyword
-const importRules = usePlugin('import', {
+const importRules = withPlugin('import', {
   default: [],
 
   // This rule only makes sense in projects that use webpack

--- a/lib/rules/index.ts
+++ b/lib/rules/index.ts
@@ -4,6 +4,7 @@ import { extended } from './extended';
 import { importRules } from './import';
 import { mochaRules } from './mocha';
 import { react } from './react';
+import { reactHooks } from './reactHooks';
 import { sharedCoreTypescript } from './sharedCoreTypescript';
 import { sharedImportTypescript } from './sharedImportTypescript';
 import { typescript } from './typescript';
@@ -18,6 +19,7 @@ export {
   sharedImportTypescript,
   mochaRules,
   react,
+  reactHooks,
   typescript,
   unicorn
 };

--- a/lib/rules/mocha.ts
+++ b/lib/rules/mocha.ts
@@ -1,6 +1,6 @@
-import { usePlugin } from '../betterRules/usePlugin';
+import { withPlugin } from '../betterRules/withPlugin';
 
-const mochaRules = usePlugin('mocha', {
+const mochaRules = withPlugin('mocha', {
   handleDoneCallback: [{ ignoreSkipped: false }],
   maxTopLevelSuites: [{ limit: 1 }],
   noAsyncDescribe: [],

--- a/lib/rules/react.ts
+++ b/lib/rules/react.ts
@@ -1,6 +1,6 @@
-import { usePlugin } from '../betterRules';
+import { withPlugin } from '../betterRules';
 
-const react = usePlugin('react', {
+const react = withPlugin('react', {
   booleanPropNaming: false,
   buttonHasType: false,
   defaultPropsMatchPropTypes: false,

--- a/lib/rules/reactHooks.ts
+++ b/lib/rules/reactHooks.ts
@@ -1,0 +1,10 @@
+import { BetterRulesRecord, withPlugin } from '../betterRules';
+
+const reactHooks: BetterRulesRecord = withPlugin('react-hooks', {
+  rulesOfHooks: [],
+  exhaustiveDeps: []
+});
+
+export {
+  reactHooks
+};

--- a/lib/rules/sharedImportTypescript.ts
+++ b/lib/rules/sharedImportTypescript.ts
@@ -1,8 +1,8 @@
 import { Language } from '../Language';
-import { BetterRulesRecord, usePlugin } from '../betterRules';
+import { BetterRulesRecord, withPlugin } from '../betterRules';
 
 const sharedImportTypescript = ({ language }: { language: Language }): BetterRulesRecord =>
-  usePlugin('import',
+  withPlugin('import',
     {
       noCommonjs: language === 'javascript' ? false : []
     });

--- a/lib/rules/typescript.ts
+++ b/lib/rules/typescript.ts
@@ -1,12 +1,12 @@
-import { BetterRulesRecord, usePlugin } from '../betterRules';
+import { BetterRulesRecord, withPlugin } from '../betterRules';
 
 const typescript: BetterRulesRecord = {
-  ...usePlugin('unicorn', {
+  ...withPlugin('unicorn', {
     // This rule is already enforced via the type system and produces false-positives.
     requirePostMessageTargetOrigin: false
   }),
 
-  ...usePlugin('@typescript-eslint', {
+  ...withPlugin('@typescript-eslint', {
     adjacentOverloadSignatures: [],
     arrayType: [{ default: 'array' }],
     awaitThenable: [],

--- a/lib/rules/unicorn.ts
+++ b/lib/rules/unicorn.ts
@@ -1,6 +1,6 @@
-import { usePlugin } from '../betterRules';
+import { withPlugin } from '../betterRules';
 
-const unicorn = usePlugin('unicorn', {
+const unicorn = withPlugin('unicorn', {
   betterRegex: [{ sortCharacterClasses: true }],
   catchErrorName: [{ name: 'ex', ignore: [ '^ex([AZ0-9].*)?$' ]}],
   consistentDestructuring: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint-plugin-import": "2.25.2",
         "eslint-plugin-mocha": "9.0.0",
         "eslint-plugin-react": "7.27.1",
+        "eslint-plugin-react-hooks": "4.2.0",
         "eslint-plugin-unicorn": "37.0.1"
       }
     },
@@ -3432,6 +3433,18 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
+      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/estraverse": {
@@ -16298,6 +16311,13 @@
           "peer": true
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
+      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "peer": true,
+      "requires": {}
     },
     "eslint-plugin-unicorn": {
       "version": "37.0.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-import": "2.25.2",
     "eslint-plugin-mocha": "9.0.0",
     "eslint-plugin-react": "7.27.1",
+    "eslint-plugin-react-hooks": "4.2.0",
     "eslint-plugin-unicorn": "37.0.1"
   },
   "scripts": {

--- a/test/integration/rules/reactHooksTests.ts
+++ b/test/integration/rules/reactHooksTests.ts
@@ -1,5 +1,5 @@
-import { assertLint } from '../assertLint';
-import { lintJsx } from '../esLintTester';
+import { assertLint } from '../../shared/assertLint';
+import { lintJsx } from '../../shared/esLintTester';
 
 suite('react-hooks/', (): void => {
   test('rules-of-hooks.', async (): Promise<void> => {

--- a/test/integration/rules/reactHooksTests.ts
+++ b/test/integration/rules/reactHooksTests.ts
@@ -1,0 +1,30 @@
+import { assertLint } from '../assertLint';
+import { lintJsx } from '../esLintTester';
+
+suite('react-hooks/', (): void => {
+  test('rules-of-hooks.', async (): Promise<void> => {
+    const result = await lintJsx(`
+        const MyComponent = () => {
+          if(true) {
+            const [state, setState] = useState('');
+          }
+          return (<p>content</p>);
+        };
+    `);
+
+    assertLint(result).containsError('react-hooks/rules-of-hooks');
+  });
+
+  test('exhaustive-deps.', async (): Promise<void> => {
+    const result = await lintJsx(`
+        const MyComponent = ({ dependency }) => {
+          useEffect(() => {
+            dependency.useIt();
+          }, [])
+          return (<p>content</p>);
+        };
+    `);
+
+    assertLint(result).containsError('react-hooks/exhaustive-deps');
+  });
+});

--- a/test/unit/betterRules/withPluginTests.ts
+++ b/test/unit/betterRules/withPluginTests.ts
@@ -1,9 +1,9 @@
 import { assert } from 'assertthat';
-import { usePlugin } from '../../../lib/betterRules/usePlugin';
+import { withPlugin } from '../../../lib/betterRules/withPlugin';
 
-suite('usePlugin', (): void => {
+suite('withPlugin', (): void => {
   test('attaches the given plugin name to all given rules.', async (): Promise<void> => {
-    const rules = usePlugin('@eslint-typescript', {
+    const rules = withPlugin('@eslint-typescript', {
       firstRule: false,
       secondRule: []
     });
@@ -15,7 +15,7 @@ suite('usePlugin', (): void => {
   });
 
   test('uses currying to allow predefined hooks.', async (): Promise<void> => {
-    const useTypescript = usePlugin('@eslint-typescript');
+    const useTypescript = withPlugin('@eslint-typescript');
 
     const rules = useTypescript({
       myRule: false


### PR DESCRIPTION
This is built on top of #433 and can only be merged after. It fixes #426 .

I had to rename the `usePlugin` to `withPlugin` in this PR as `usePlugin` now was interpreted by the plugin as react-hook and errored as we do not use it within react-components.

There is no way to define a ignore-list right now.