### PR TITLE
chore: Makes goloroden the only person allowed to change the rules-directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-*       @goloroden
+*               @dotKuro @goloroden @strangedev @yeldiRium @davelosert
+lib/rules       @goloroden


### PR DESCRIPTION
@goloroden : Finally I came around to adress this task as well.

I hope this works the way it is intended (according to the [GitHub Docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file) it should work like this).

One more additional note: I found out that you can also specify teams as code-owner rather than only individuals.
So maybe it would be a good idea to change the code-owners to an internal `thenativeweb` team?