### PR TITLE
feat: allow explicitly typed function expressions

### DIFF
--- a/lib/rules/typescript.ts
+++ b/lib/rules/typescript.ts
@@ -37,7 +37,7 @@ const typescript: BetterRulesRecord = {
     defaultParamLast: [],
     explicitFunctionReturnType: [{
       allowExpressions: false,
-      allowTypedFunctionExpressions: false,
+      allowTypedFunctionExpressions: true,
       allowHigherOrderFunctions: false
     }],
     explicitMemberAccessibility: [{

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/eslint": "8.4.1",
-        "@types/lodash": "4.14.178",
+        "@types/lodash": "4.14.179",
         "assertthat": "6.4.0",
         "react": "17.0.2",
         "roboter": "12.7.0",
@@ -981,9 +981,9 @@
       "peer": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.178",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
+      "version": "4.14.179",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
+      "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -12296,9 +12296,9 @@
       "peer": true
     },
     "@types/lodash": {
-      "version": "4.14.178",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
+      "version": "4.14.179",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
+      "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==",
       "dev": true
     },
     "@types/minimatch": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/eslint": "8.4.1",
-    "@types/lodash": "4.14.178",
+    "@types/lodash": "4.14.179",
     "assertthat": "6.4.0",
     "react": "17.0.2",
     "roboter": "12.7.0",

--- a/test/integration/rules/typeScriptTests.ts
+++ b/test/integration/rules/typeScriptTests.ts
@@ -12,6 +12,34 @@ suite('@typescript-eslint/', (): void => {
     assertLint(result).containsError('@typescript-eslint/consistent-type-definitions');
   });
 
+  test('explicitFunctionReturnType: allows for explicitly typed functions.', async (): Promise<void> => {
+    let result = await lintTypescript(`
+      type ExplicitType = () => number;
+      
+      const test: ExplicitType = () => 3; 
+    `);
+
+    assertLint(result).notContainsError('@typescript-eslint/explicit-function-return-type');
+
+    result = await lintTypescript(`
+      const numberer = function (fn: (first: number, second: number) => number): number {
+        return fn(2, 2);
+      };
+      
+      const foobar = numberer((first, second) => first * second);
+    `);
+
+    assertLint(result).notContainsError('@typescript-eslint/explicit-function-return-type');
+  });
+
+  test('explicitFunctionReturnType: still requires explicit return types on function declarations.', async (): Promise<void> => {
+    const result = await lintTypescript(`    
+      const test = () => 3; 
+    `);
+
+    assertLint(result).containsError('@typescript-eslint/explicit-function-return-type');
+  });
+
   test('unicorn/require-post-message-target-origin: is deactivated for typescript files to avoid false-positives.', async (): Promise<void> => {
     const passing = await lintTypescript(`window.postMessage('myMessage');`);
 


### PR DESCRIPTION
This enables the option [`allowTypedFunctionExpressions`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/explicit-function-return-type.md#allowtypedfunctionexpressions) of `@typescript-eslint/explicit-function-return-type`.

What this means is that function can omit specifying their return type explicitly, if the function expression is explicitly typed otherwise. Explicitly typed applies to:

1. Explicit type in the function declaration:

```ts
type ExplicitType = () => number;

const test: ExplicitType = () => 3; 
``` 

2. Explicit type inferred by use of the function:
```ts
const numberer = function (fn: (first: number, second: number) => number): number {
  return fn(2, 2);
};
      
const foobar = numberer((first, second) => first * second);
```

This change does **not** apply to function declarations in general, even if the return type could be inferred from the function expression:

```ts
const test = () => 3;
```